### PR TITLE
Add monitoring config to setup script

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -31,7 +31,7 @@ The file should contain the ansible-vault password on a single line. Do not comm
     - Debian 9.4 x64
     - Standard 1GB mem, 1 vCPU, 25 GB SSD, 1 TB transfer at $5/mo
     - New York 3 datacenter region
-    - Enable monitoring
+    - Leave monitoring disabed (the setup script will set it up for us)
     - Choose your SSH key
 
 3. Add the droplet to the DigitalOcean firewall named Common. If you don't have access to this one,

--- a/ansible/setup/main.yml
+++ b/ansible/setup/main.yml
@@ -56,6 +56,7 @@
           - postfix
           - debconf
           - debconf-utils
+          - curl
     - name: Configure APT update intervals
       copy:
         src: apt-auto-upgrades
@@ -95,6 +96,8 @@
         regexp: ^/usr/sbin/logwatch
         line: /usr/sbin/logwatch --output mail --mailto {{ logwatch_email }} --detail high
         create: yes
+    - name: Enable DigitalOcean Monitoring
+      command: curl -sSL https://agent.digitalocean.com/install.sh | sh
     - name: Add deploy user
       user:
         name: "{{ deploy_user_name }}"


### PR DESCRIPTION
For some reason, the monitoring wasn't getting set up correctly by the Create Droplet form on DigitalOcean, so I'm moving it to the setup script.