### PR TITLE
Enforce the hostname when serving requests

### DIFF
--- a/ansible/nginx/build-nginx/default.conf
+++ b/ansible/nginx/build-nginx/default.conf
@@ -1,6 +1,11 @@
 server {
     listen 80;
-    server_name localhost;
+    return 444;
+}
+
+server {
+    listen 80;
+    server_name .bedfordvamuseum.org;
 
     location / {
         root   /usr/share/nginx/html;
@@ -15,7 +20,6 @@ server {
     }
 
     # redirect server error pages to the static page /50x.html
-    #
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
A while ago, I noticed that we were getting a bunch of traffic from some other domain which still had DNS entries pointing to our new server. This change makes it so that nginx will reject those requests and will only serve requests where bedfordvamuseum.org is the host.