### PR TITLE
Fix rclone cron job setup

### DIFF
--- a/ansible/load_content/main.yml
+++ b/ansible/load_content/main.yml
@@ -40,7 +40,7 @@
         mode: 0775
       become: yes
     - name: Transfer static site content
-      command: rclone --config=.config/rclone/rclone.conf sync spaces:bedfordvamuseum/static /var/sftp/bedfordvamuseum
+      command: rclone --config=/home/deploy/.config/rclone/rclone.conf sync spaces:bedfordvamuseum/static /var/sftp/bedfordvamuseum
       become: yes
     - name: Create /var/sftp/bedfordvamuseum directory
       file:
@@ -60,6 +60,6 @@
       cron:
         name: spaces sync
         special_time: daily
-        job: rclone --config=.config/rclone/rclone.conf sync /var/sftp/bedfordvamuseum spaces:bedfordvamuseum/static
+        job: rclone --config=/home/deploy/.config/rclone/rclone.conf sync /var/sftp/bedfordvamuseum spaces:bedfordvamuseum/static
       when: prod
       become: yes


### PR DESCRIPTION
During the latest server migration, I noticed that the cron job I set up to keep the static content synced to a DigitalOcean Spaces bucket was failing. The problem was that cron runs as `root`, but the rclone config is in the `deploy` home directory. This change changes the command so that the rclone config can be located correctly.